### PR TITLE
feat: Add repository data access contracts (US-00102)

### DIFF
--- a/.github/agents/senior-engineer.agent.md
+++ b/.github/agents/senior-engineer.agent.md
@@ -102,13 +102,20 @@ Every PHP file must include this header block:
 <?php
 
 /**
- * @author    Paul Slits <paul.slits@gmail.com>
- * @copyright (c) 2025 Paul Slits
+ * [Short description of the file's purpose]
+ *
+ * @author    [author] <[email]>
+ * @copyright (c) [Year when created] Paul Slits
  * @license   MIT License - https://opensource.org/licenses/MIT
  * @link      https://github.com/pslits/oai-pmh
- * @since     0.1.0
+ * @since     [Project version when created]
  */
 ```
+
+**Note:** The `@since` version should match the `"version"` field in `composer.json` at the time the file was created. Check `composer.json` for the current version (currently `0.1.0`).
+
+### Code Documentation
+- Add docblocks to all new PHP classes, methods, and properties following PHPDoc standards
 
 ### Domain-Driven Design Patterns
 
@@ -196,6 +203,6 @@ vendor/bin/phpcbf
 ## Remember
 - Quality over speed
 - Write code that is easy to read and maintain
-- Document the "why" not just the "what"
+- Use concise, modern PHP 8.0 documentation (let type hints speak)
 - Think about the domain, not just the code
 - Every class should tell a story about the domain

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,26 +32,17 @@ Every PHP file must include this header block:
 <?php
 
 /**
- * @author    Paul Slits <paul.slits@gmail.com>
- * @copyright (c) 2025 Paul Slits
+ * [Short description of the file's purpose]
+ *
+ * @author    [author] <[email]>
+ * @copyright (c) [Year when created] Paul Slits
  * @license   MIT License - https://opensource.org/licenses/MIT
  * @link      https://github.com/pslits/oai-pmh
- * @since     0.1.0
+ * @since     [Project version when created]
  */
 ```
 
-### Class Documentation
-- Every class must have a comprehensive docblock
-- Explain what the class represents and its purpose
-- For value objects, mention: encapsulation, immutability, value equality
-- Document any validation rules or constraints
-
-### Method Documentation
-- All public methods require docblocks with clear descriptions
-- Document `@param` with type and description
-- Document `@return` with type and description
-- Document `@throws` for any exceptions that may be thrown
-- Private methods should have docblocks if the logic is complex
+**Note:** The `@since` version should match the `"version"` field in `composer.json` at the time the file was created. Check `composer.json` for the current version (currently `0.1.0`).
 
 ## Domain-Driven Design Patterns
 
@@ -89,7 +80,6 @@ final class ExampleValue
     /**
      * Constructs a new ExampleValue instance.
      *
-     * @param string $exampleValue The value to encapsulate.
      * @throws InvalidArgumentException If validation fails.
      */
     public function __construct(string $exampleValue)
@@ -100,8 +90,6 @@ final class ExampleValue
 
     /**
      * Returns the example value (domain-specific getter).
-     *
-     * @return string The encapsulated value.
      */
     public function getExampleValue(): string
     {
@@ -112,8 +100,6 @@ final class ExampleValue
      * Returns the value (alias for getExampleValue).
      *
      * Provided for consistency with other value objects.
-     *
-     * @return string The encapsulated value.
      */
     public function getValue(): string
     {
@@ -122,9 +108,6 @@ final class ExampleValue
 
     /**
      * Checks if this ExampleValue is equal to another.
-     *
-     * @param ExampleValue $otherExampleValue The other instance to compare with.
-     * @return bool True if both have the same value, false otherwise.
      */
     public function equals(self $otherExampleValue): bool
     {
@@ -134,7 +117,7 @@ final class ExampleValue
     /**
      * Returns a string representation of the ExampleValue object.
      *
-     * @return string A string representation.
+     * Format: `ExampleValue(value: <value>)`
      */
     public function __toString(): string
     {
@@ -149,7 +132,6 @@ final class ExampleValue
      * - validateFormat()
      * - validateBusinessRule()
      *
-     * @param string $exampleValue The value to validate.
      * @throws InvalidArgumentException If validation fails.
      */
     private function validate(string $exampleValue): void
@@ -161,7 +143,6 @@ final class ExampleValue
     /**
      * Validates that the value is not empty.
      *
-     * @param string $exampleValue The value to validate.
      * @throws InvalidArgumentException If the value is empty.
      */
     private function validateNotEmpty(string $exampleValue): void
@@ -308,389 +289,8 @@ When changing value object method signatures:
 - Validate metadata formats according to standards
 - Handle protocol-specific data types correctly (e.g., UTC datetime, granularity)
 
-### OAI-PMH Documentation Requirements
-Every value object representing an OAI-PMH concept must include:
-1. **Class Docblock**: Reference the specific OAI-PMH 2.0 specification section
-   - Example: "According to OAI-PMH 2.0 specification section 4.2 (Identify)..."
-2. **Explain the OAI-PMH Context**: What part of the protocol does this implement?
-3. **List Allowed Values**: For enumeration types (e.g., DeletedRecord: no/transient/persistent)
-4. **Protocol Requirements**: Whether required or optional in OAI-PMH responses
-5. **Format Specifications**: For formatted values (e.g., UTC datetime, granularity patterns)
-6. **Usage Context**: Where this value appears in OAI-PMH responses
-
-Example:
-```php
-/**
- * Represents the OAI-PMH deletedRecord support policy as a value object.
- *
- * According to OAI-PMH 2.0 specification section 3.5 (Deleted Records), repositories
- * must declare how they handle deleted records using one of three values:
- * - 'no': repository does not maintain information about deletions
- * - 'transient': repository maintains deletion info but not persistently/completely
- * - 'persistent': repository maintains complete deletion info with no time limit
- *
- * This value object:
- * - encapsulates a validated deletedRecord value,
- * - is immutable and compared by value (not identity),
- * - ensures only allowed deletedRecord values are accepted,
- * - is required in the OAI-PMH Identify response.
- */
-final class DeletedRecord
-{
-    // ...
-}
-```
-
-## Value Object Analysis Documentation
-
-### Purpose
-**Each individual value object** must have its own comprehensive analysis document that provides detailed documentation about its design, implementation, testing, and OAI-PMH compliance.
-
-### When to Create Analysis Documents
-- **REQUIRED**: After implementing each new value object (one document per value object)
-- When completing a feature branch that adds domain objects
-- For any value object or collection class
-- When documenting design decisions for future reference
-
-### Analysis Document Structure
-
-Create **separate** analysis documents in the `docs/analysis/ValueObject/` directory with naming pattern: `docs/analysis/ValueObject/{VALUEOBJECT}_ANALYSIS.md`
-
-**Examples:**
-- `docs/analysis/ValueObject/BASEURL_ANALYSIS.md` - Individual BaseURL value object analysis
-- `docs/analysis/ValueObject/REPOSITORYNAME_ANALYSIS.md` - Individual RepositoryName value object analysis  
-- `docs/analysis/ValueObject/DESCRIPTIONCOLLECTION_ANALYSIS.md` - Individual DescriptionCollection analysis
-- `docs/analysis/ValueObject/EMAIL_ANALYSIS.md` - Individual Email value object analysis
-- etc.
-
-**Note:** Each value object gets its own dedicated analysis file following the detailed template below.
-
-### Required Sections
-
-Follow the structure from `docs/analysis/ValueObject/DESCRIPTIONCOLLECTION_ANALYSIS.md`, `docs/analysis/ValueObject/BASEURL_ANALYSIS.md`, or `docs/analysis/ValueObject/REPOSITORYNAME_ANALYSIS.md`:
-
-1. **Document Header**
-   - Analysis date
-   - Component name (e.g., "BaseURL Value Object")
-   - File path (e.g., `src/Domain/ValueObject/BaseURL.php`)
-   - OAI-PMH Version: 2.0
-   - Specification reference link
-
-2. **OAI-PMH Requirement** (Section 1)
-   - Specification context (quote from OAI-PMH spec)
-   - Key requirements (bullet list)
-   - XML example from specification
-   - Common patterns or usage table
-   - OAI-PMH compliance notes
-
-3. **User Story** (Section 2)
-   - Story template (As a.../When.../Where.../I want.../Because...)
-   - Complete context for why this value object exists
-   - Acceptance criteria with checkboxes [x]
-   - All must be checked/satisfied
-
-4. **Implementation Details** (Section 3)
-   - File structure
-   - Class structure (code block showing methods)
-   - Design characteristics table (Aspect | Implementation | OAI-PMH Alignment | Status)
-   - Validation logic with code examples
-   - Relationship to other components (ASCII diagram)
-
-5. **Acceptance Criteria** (Section 4)
-   - Functional requirements table with test coverage mapping
-   - OAI-PMH protocol compliance table
-   - Non-functional requirements table
-   - Each row with ✅ PASS or ⚠️ status
-
-6. **Test Coverage Analysis** (Section 5)
-   - Test statistics table (total tests, assertions, coverage percentages)
-   - Test categories with test names
-   - Test quality assessment (strengths and any coverage gaps)
-   - Specific test examples showing BDD style
-
-7. **Code Examples** (Section 6)
-   - Basic usage with code blocks
-   - Validation examples (valid and invalid cases)
-   - Integration with other value objects
-   - Real-world usage scenarios
-
-8. **Design Decisions** (Section 7)
-   - Each major decision as subsection (Decision 1, 2, 3...)
-   - Context/Options Considered/Rationale/Trade-offs for each
-   - Code examples showing the decision
-   - Justification from OAI-PMH spec where applicable
-
-9. **Known Issues & Future Enhancements** (Section 8)
-   - Current known issues (if any)
-   - Future enhancements with priority levels
-   - Migration notes (e.g., PHP 8.2 readonly)
-   - Related GitHub issue numbers
-
-10. **Comparison with Related Value Objects** (Section 9)
-    - Pattern consistency table
-    - Comparison with similar VOs in the library
-    - Why this VO vs. reusing existing ones
-
-11. **Recommendations** (Section 10)
-    - For developers using the VO
-    - For repository administrators
-    - For library maintainers
-    - DO/DON'T lists with examples
-
-12. **References** (Section 11)
-    - OAI-PMH specification links
-    - Related standards (RFCs, etc.)
-    - Related analysis documents
-    - Related GitHub issues
-
-13. **Appendix** (Section 12)
-    - Complete test output
-    - Code coverage report
-    - PHPStan analysis results
-    - PHP CodeSniffer results
-    - Real-world examples (if applicable)
-
-### Example Analysis Template
-
-```markdown
-# {Component Name} Analysis
-
-**Analysis Date:** {Date}  
-**Component:** {Name}  
-**Branch:** {branch-name}  
-**Status:** {Completed/In Progress/etc.}
-
----
-
-## Executive Summary
-
-Brief 2-3 sentence overview of what this component does and its importance.
-
----
-
-## Value Object Overview
-
-### Purpose
-What problem does this solve in the domain?
-
-### OAI-PMH Context
-Which part of the OAI-PMH specification does this implement?
-
-### Key Characteristics
-- Characteristic 1
-- Characteristic 2
-
----
-
-## Implementation
-
-### File Structure
-```
-src/Domain/ValueObject/{Name}.php
-tests/Domain/ValueObject/{Name}Test.php
-```
-
-### Class Design
-- **Namespace:** OaiPmh\Domain\ValueObject
-- **Type:** final class
-- **Implements:** Interface1, Interface2
-
-### Properties
-| Property | Type | Visibility | Description |
-|----------|------|------------|-------------|
-| $property1 | Type | private | Purpose |
-
-### Methods
-| Method | Parameters | Return | Purpose |
-|--------|------------|--------|---------|
-| __construct() | ... | void | Initialize |
-| getValue() | none | Type | Get value |
-| equals() | self $other | bool | Value equality |
-| __toString() | none | string | String repr |
-
-### Validation Rules
-1. Rule 1: Description
-2. Rule 2: Description
-
----
-
-## Design Decisions
-
-### Decision 1: {Title}
-**Why:** Explanation
-**Alternatives:** What else was considered
-**Trade-offs:** Benefits vs. drawbacks
-
----
-
-## Code Examples
-
-### Basic Usage
-```php
-// Example code
-```
-
-### Advanced Usage
-```php
-// Example code
-```
-
----
-
-## Test Coverage
-
-### Statistics
-- **Total Tests:** X
-- **Assertions:** Y
-- **Coverage:** Z%
-- **Status:** All passing
-
-### Test Categories
-- ✅ Constructor validation (X tests)
-- ✅ Value equality (Y tests)
-- ✅ Immutability (Z tests)
-- ✅ String representation (W tests)
-- ✅ Edge cases (V tests)
-
-### Test Quality
-- BDD-style Given-When-Then ✅
-- User story comments ✅
-- Descriptive test names ✅
-- Comprehensive assertions ✅
-
----
-
-## Quality Metrics
-
-| Metric | Result | Status |
-|--------|--------|--------|
-| PHPStan Level 8 | 0 errors | ✅ |
-| PSR-12 Compliance | 100% | ✅ |
-| Code Coverage | X% | ✅/⚠️ |
-| CRAP Index | Low | ✅ |
-
----
-
-## Usage Guidelines
-
-### When to Use
-- Scenario 1
-- Scenario 2
-
-### Best Practices
-1. Practice 1
-2. Practice 2
-
-### Common Pitfalls
-- ❌ Don't do X
-- ✅ Instead do Y
-
----
-
-## Future Enhancements
-
-### Planned
-- [ ] Enhancement 1 (Issue #X)
-- [ ] Enhancement 2 (Issue #Y)
-
-### Known Issues
-- Issue 1 (Issue #X): Description
-- Issue 2 (Issue #Y): Description
-
-### Migration Notes
-- PHP 8.2: TODO #8 - Convert to readonly properties
-
----
-
-## References
-
-- [OAI-PMH Specification](https://www.openarchives.org/OAI/openarchivesprotocol.html)
-- Related analysis documents
-- GitHub issues
-- External resources
-
----
-
-*Analysis generated on {Date}*
-```
-
-### Best Practices for Analysis Documents
-
-1. **Keep It Current**
-   - Update after significant changes
-   - Version control with the code
-   - Reference specific code line numbers sparingly (they change)
-
-2. **Be Comprehensive but Concise**
-   - Include all important information
-   - Use tables and lists for clarity
-   - Link to external resources rather than duplicating
-
-3. **Focus on "Why" Not "What"**
-   - Code shows "what"
-   - Analysis explains "why"
-   - Document design decisions and trade-offs
-
-4. **Include Practical Examples**
-   - Real-world usage scenarios
-   - Integration patterns
-   - Common combinations
-
-5. **Maintain Quality Metrics**
-   - Track coverage trends
-   - Document quality improvements
-   - Highlight areas needing attention
-
-6. **Cross-Reference**
-   - Link to related value objects
-   - Reference OAI-PMH spec sections
-   - Connect to GitHub issues
-
-### Updating Analysis Documents After Refactoring
-
-When modifying existing value objects, update their analysis documents to reflect changes:
-
-**When to Update:**
-- ✅ New methods added (e.g., domain-specific getters)
-- ✅ Validation logic refactored (e.g., split into multiple methods)
-- ✅ Parameter names changed (affects code examples)
-- ✅ New design decisions made
-- ⚠️ Simple docblock improvements (optional unless significant)
-- ⚠️ Backward-compatible changes (document in "Design Decisions" section)
-
-**What to Update:**
-1. **Implementation Details Section**: Update class structure table with new methods
-2. **Code Examples Section**: Update examples using new method names
-3. **Design Decisions Section**: Add new decision subsections with context/rationale
-4. **Test Coverage Analysis**: Update if new tests added
-5. **Known Issues & Future Enhancements**: Mark completed TODOs
-6. **Document metadata**: Update "Analysis Date" in header
-
-**Example Update Flow:**
-```markdown
-## Design Decisions
-
-### Decision 4: Domain-Specific Getter Method
-**Context:** Originally provided only getValue() for accessing the value
-**Why:** Adding getBaseUrl() improves code readability and self-documentation
-**Alternatives:** Keep only getValue() for consistency
-**Trade-offs:** 
-- ✅ Benefit: More expressive, domain-driven API
-- ✅ Benefit: Backward compatible (getValue() kept as alias)
-- ⚠️ Trade-off: Two method names for same functionality
-**Implementation:**
-```php
-public function getBaseUrl(): string
-{
-    return $this->value;
-}
-
-public function getValue(): string  // Alias for backward compatibility
-{
-    return $this->value;
-}
-```
-```
+### Code Documentation
+- Add docblocks to all new PHP classes, methods, and properties following PHPDoc standards
 
 ## Additional Best Practices
 

--- a/.github/skills/domain-driven-design.md
+++ b/.github/skills/domain-driven-design.md
@@ -155,3 +155,25 @@ All value objects in the library should follow this pattern:
 - etc.
 
 **Do NOT** mix patterns (some with `getValue()`, some without).
+
+## Domain Method Naming Checklist
+
+When naming methods in OAI-PMH domain:
+
+1. **Check OAI-PMH specification** for exact terminology
+   - Verbs: GetRecord, ListRecords, Identify, ListMetadataFormats
+   - Nouns: metadata, datestamp, set, identifier, granularity
+
+2. **Avoid generic patterns**:
+   - ❌ `findByIdentifier()` - repository pattern language
+   - ✅ `getRecord()` - OAI-PMH domain language
+   - ❌ `getMetadataContent()` - redundant qualifier
+   - ✅ `getMetadata()` - matches specification
+
+3. **Maintain consistency**:
+   - If `listRecords()` uses domain language, so should `getRecord()`
+   - All methods in an interface should follow same naming conventions
+
+4. **Self-documenting names**:
+   - Method name should be self-explanatory to domain experts
+   - Should read naturally when implementing OAI-PMH verbs

--- a/.github/skills/php-docblock/LICENSE.txt
+++ b/.github/skills/php-docblock/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/.github/skills/php-docblock/SKILL.md
+++ b/.github/skills/php-docblock/SKILL.md
@@ -1,0 +1,264 @@
+```skill
+---
+name: php-docblock
+description: Write PHP docblocks for PHP 8.0+ following modern PHPDoc conventions. Use when (1) adding or updating docblocks on PHP classes, methods, or properties, (2) annotating ORM models with @property tags, (3) documenting service or manager method signatures, (4) generating PHPDoc for controllers, form requests, or service classes, or (5) asked to document PHP code. Triggers on phrases like "add docblocks", "document this class", "PHPDoc", "annotate model", or "type hints".
+---
+
+# PHP Docblock Writer
+
+## Core Principle
+
+PHP 8.0 native type declarations are the source of truth. Docblocks **complement** — never duplicate — what the language already expresses. Add a docblock only when it provides information beyond the signature.
+
+**Minimal docblock philosophy for this project:**
+- Let type hints speak (native types are the source of truth)
+- Avoid duplication (don't repeat what's already in the signature)
+- Add docblocks only when providing additional context
+- Comprehensive documentation belongs in markdown files, not code comments
+- Skip entire docblocks when they would only mirror the signature without adding value
+
+### When to Write a Docblock
+
+| Situation | Example |
+|---|---|
+| Description adds context | What a method does, not just its name |
+| Type is more specific than the signature | `@return Collection<int, User>` vs `: Collection` |
+| Array shape needs documenting | `@param array{name: string, age: int} $data` |
+| Magic properties/methods exist | ORM model `@property`, service `@method` |
+| `@throws` documents expected exceptions | `@throws ModelNotFoundException` |
+| Deprecation notice | `@deprecated Use newMethod() instead` |
+
+### When to Skip
+
+- Signature already says everything and the method name is self-explanatory
+- Simple getters/setters with typed properties
+- Closures and short arrow functions with obvious behavior
+
+## Tag Reference
+
+### Standard Tags
+
+```php
+/**
+ * Store a newly created resource.
+ *
+ * @param  StoreUserRequest  $request
+ * @return JsonResponse
+ *
+ * @throws AuthorizationException
+ */
+public function store(StoreUserRequest $request): JsonResponse
+```
+
+Ordering rules:
+
+1. Summary line (one sentence, no period if short)
+2. Blank line
+3. Long description (optional, wrap at 80 chars)
+4. Blank line
+5. Tags in this order: `@template`, `@param`, `@return`, `@throws`, `@deprecated`, `@see`
+
+### Alignment
+
+Align `@param` types and variable names into columns. Two spaces between type and variable:
+
+```php
+/**
+ * @param  string       $name
+ * @param  int          $age
+ * @param  string|null  $email
+ */
+```
+
+### Type Syntax
+
+| PHP 8.0 native | Docblock equivalent (use only when adding information) |
+|---|---|
+| `string` | `string` |
+| `?string` | `string\|null` (prefer explicit union in docblocks) |
+| `int\|string` | `int\|string` |
+| `array` | `array<string, mixed>`, `array{key: type}`, `list<int>` |
+| `mixed` | Avoid — be specific when possible |
+| `self` | `static` when return type supports chaining |
+| `object` | Specific class name when known |
+
+## Common Patterns
+
+### ORM Models (Magic Properties and Methods)
+
+Annotate every mapped column, cast, and relationship accessor as `@property` or `@property-read` on the class docblock:
+
+```php
+/**
+ * @property int         $id
+ * @property string      $name
+ * @property string      $email
+ * @property Carbon|null $email_verified_at
+ * @property string      $password
+ * @property Carbon      $created_at
+ * @property Carbon      $updated_at
+ *
+ * @property-read Collection<int, Notification> $notifications
+ * @property-read Collection<int, Role>         $roles
+ *
+ * @method static UserFactory  factory($count = null, $state = [])
+ * @method static Builder|User query()
+ * @method static Builder|User whereEmail(string $value)
+ */
+class User extends Model
+```
+
+Rules:
+- Use `@property-read` for relationships and computed accessors
+- Use `@property` for mapped/castable columns
+- Use the cast target type (e.g., `Carbon` not `string` for date casts)
+- Add `@method static` for query scopes and static factory methods
+
+### Controller Methods
+
+```php
+/**
+ * Display a listing of users.
+ *
+ * @return View
+ */
+public function index(): View
+
+/**
+ * Update the specified user.
+ *
+ * @param  UpdateUserRequest  $request
+ * @param  User               $user
+ * @return RedirectResponse
+ *
+ * @throws AuthorizationException
+ */
+public function update(UpdateUserRequest $request, User $user): RedirectResponse
+```
+
+For CRUD controllers, a one-line summary is enough — the method name (`index`, `store`, `show`, `update`, `destroy`) already communicates intent.
+
+### Form Requests
+
+```php
+/**
+ * Determine if the user is authorized.
+ *
+ * @return bool
+ */
+public function authorize(): bool
+
+/**
+ * Validation rules.
+ *
+ * @return array<string, ValidationRule|array<mixed>|string>
+ */
+public function rules(): array
+```
+
+### Service / Action Classes
+
+```php
+/**
+ * Calculate the order total including tax and discounts.
+ *
+ * @param  Order                    $order
+ * @param  Collection<int, Coupon>  $coupons
+ * @return Money
+ *
+ * @throws InsufficientStockException
+ */
+public function calculateTotal(Order $order, Collection $coupons): Money
+```
+
+### Collections and Generics
+
+Use PHPStan-style generic syntax:
+
+```php
+/** @var Collection<int, User> */
+
+/** @return LengthAwarePaginator<User> */
+
+/** @param  iterable<int, string>  $items */
+```
+
+Common generic forms:
+
+| Type | Generic form |
+|---|---|
+| `Collection` | `Collection<TKey, TValue>` |
+| `EloquentCollection` | `Collection<int, Model>` |
+| `LengthAwarePaginator` | `LengthAwarePaginator<Model>` |
+| `Builder` | `Builder<Model>` |
+| `HasMany` | `HasMany<ChildModel>` |
+| `BelongsTo` | `BelongsTo<ParentModel>` |
+| `BelongsToMany` | `BelongsToMany<RelatedModel>` |
+
+### Config and Array Shapes
+
+```php
+/**
+ * @param  array{
+ *     host: string,
+ *     port: int,
+ *     username: string,
+ *     password: string,
+ *     database?: string,
+ * }  $config
+ */
+```
+
+### Closures and Callables
+
+```php
+/** @param  Closure(User, int): bool  $callback */
+
+/** @param  callable(Request): Response  $handler */
+```
+
+### Proxy / Facade `@method` Annotations
+
+When a class proxies another via magic `__call`, document the proxied methods:
+
+```php
+/**
+ * @method static CacheManager store(string|null $name = null)
+ * @method static bool         has(string $key)
+ * @method static mixed        get(string $key, mixed $default = null)
+ * @method static bool         put(string $key, mixed $value, DateTimeInterface|DateInterval|int|null $ttl = null)
+ * @method static bool         forget(string $key)
+ *
+ * @see \Cache\CacheManager
+ */
+class Cache extends Proxy
+```
+
+Always add `@see` pointing to the underlying class.
+
+## Inline Annotations
+
+Use `/** @var Type */` for variables where the type cannot be inferred:
+
+```php
+/** @var User $user */
+$user = $container->get(User::class);
+
+/** @var Collection<int, Order> $orders */
+$orders = $repository->findOrdersByUser($user);
+```
+
+Prefer single-line form for inline `@var`. Do not use `@var` when the type is already clear from context.
+
+## Checklist
+
+Before finalizing any docblock, verify:
+
+- [ ] No tag duplicates the native type signature without adding specificity
+- [ ] `@param` types match or refine the signature types
+- [ ] `@return` is present when the return type is less specific than the docblock (e.g., `Collection` → `Collection<int, User>`)
+- [ ] Array types use shape or generic syntax, never bare `array`
+- [ ] `@throws` lists only exceptions the caller should handle
+- [ ] Alignment is consistent within each block
+- [ ] Summary line is concise and uses imperative mood ("Store", "Calculate", not "Stores", "This method calculates")
+```

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "OAI-PMH protocol implementation in PHP",
     "type": "library",
     "license": "MIT",
-    "version ": "0.1.0",
+    "version": "0.1.0",
     "authors": [
         {
             "name": "Paul Slits",
@@ -27,6 +27,9 @@
         "psr-4": {
             "OaiPmh\\Tests\\": "tests/"
         }
+    },
+    "require": {
+        "php": ">=8.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b5b2cdc1f40822d29394ced139aa68a",
+    "content-hash": "183d03aca96cebd256060b12efd6dfbf",
     "packages": [],
     "packages-dev": [
         {
@@ -1904,7 +1904,9 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": ">=8.0"
+    },
     "platform-dev": {},
     "plugin-api-version": "2.6.0"
 }

--- a/src/Domain/ValueObject/AnyUri.php
+++ b/src/Domain/ValueObject/AnyUri.php
@@ -16,14 +16,9 @@ use InvalidArgumentException;
 /**
  * Represents a URI that conforms to the XML Schema anyURI type.
  *
- * This value object:
- * - encapsulates a validated URI,
- * - is immutable and compared by value (not identity),
- * - ensures URIs are suitable for XML serialization in OAI-PMH responses.
- *
- * Validation is performed using PHP's filter_var function with the FILTER_VALIDATE_URL flag,
- * which is stricter than XML Schema's anyURI and may reject some valid anyURI values.
- * This is a pragmatic choice for most OAI-PMH use cases, but not a full XML Schema anyURI check.
+ * This immutable value object validates URIs against the anyURI XSD schema, ensuring
+ * they are suitable for XML serialization in OAI-PMH responses. Value equality is
+ * compared by the URI string content.
  */
 class AnyUri
 {
@@ -36,7 +31,7 @@ class AnyUri
      *
      * Validates the provided URI against the anyURI XSD schema.
      *
-     * @param string $uri The URI to validate and store.
+     * @throws InvalidArgumentException If the URI is not valid according to the anyURI schema.
      */
     public function __construct(string $uri)
     {
@@ -46,10 +41,8 @@ class AnyUri
 
     /**
      * Returns a string representation of the AnyUri object.
-     * The string format is presented as:
-     * `AnyUri(uri: <uri>)`
      *
-     * @return string A string representation of the AnyUri.
+     * Format: `AnyUri(uri: <uri>)`
      */
     public function __toString(): string
     {
@@ -58,8 +51,6 @@ class AnyUri
 
     /**
      * Returns the stored URI.
-     *
-     * @return string The validated URI.
      */
     public function getValue(): string
     {
@@ -71,10 +62,7 @@ class AnyUri
      *
      * Security: Uses textContent to prevent XML injection.
      *
-     * @param string $_uri The URI to validate.
-     *
      * @throws InvalidArgumentException If the URI is not valid according to the anyURI schema.
-     * @return void
      */
     private function validateAnyUri(string $_uri): void
     {
@@ -116,9 +104,6 @@ class AnyUri
 
     /**
      * Checks if this AnyUri is equal to another.
-     *
-     * @param AnyUri $other The other AnyUri to compare against.
-     * @return bool True if both URIs are equal, false otherwise.
      */
     public function equals(AnyUri $other): bool
     {

--- a/src/Domain/ValueObject/BaseURL.php
+++ b/src/Domain/ValueObject/BaseURL.php
@@ -16,32 +16,25 @@ use InvalidArgumentException;
  * Represents the base URL of an OAI-PMH repository.
  *
  * According to OAI-PMH 2.0 specification section 4.2 (Identify), the baseURL is
- * the base URL of the repository - the URL that is used to submit OAI-PMH requests.
- * It must be an HTTP or HTTPS URL that accepts OAI-PMH protocol requests.
+ * the URL used to submit OAI-PMH requests to the repository. It must be an HTTP
+ * or HTTPS URL that accepts OAI-PMH protocol requests.
  *
- * This value object:
- * - encapsulates the base URL where the repository responds to OAI-PMH requests,
- * - validates that the URL is a valid HTTP or HTTPS URL,
- * - is immutable and compared by value (not identity),
- * - is used in the Identify response to indicate the repository's endpoint.
+ * This immutable value object validates that the URL is a valid HTTP or HTTPS endpoint
+ * and is used in the Identify response to indicate the repository's protocol endpoint.
+ * Value equality is compared by URL string content.
  *
  * Note: BaseURL is not extended from AnyUri because it has stricter requirements
- * (HTTP/HTTPS only) compared to generic URIs. This design choice provides clearer
- * type distinction and allows independent evolution of validation rules.
- *
- * Domain concerns such as XML serialization or protocol transport are handled outside this class.
+ * (HTTP/HTTPS only) compared to generic URIs, providing clearer type distinction.
  */
 final class BaseURL
 {
     private string $url;
 
     /**
-     * BaseURL constructor.
+     * Constructs a new BaseURL instance.
      *
-     * Initializes a new instance of the BaseURL class with validation to ensure
-     * the URL is a valid HTTP or HTTPS endpoint as required by OAI-PMH.
+     * Validates that the URL is a valid HTTP or HTTPS endpoint as required by OAI-PMH.
      *
-     * @param string $baseUrl The base URL of the OAI-PMH repository (must be HTTP or HTTPS).
      * @throws InvalidArgumentException If the URL is invalid or not HTTP/HTTPS.
      */
     public function __construct(string $baseUrl)
@@ -53,9 +46,7 @@ final class BaseURL
     /**
      * Returns a string representation of the BaseURL object.
      *
-     * Provides a human-readable format useful for debugging and logging.
-     *
-     * @return string A string representation in the format: BaseURL(url: <url>)
+     * Format: `BaseURL(url: <url>)`
      */
     public function __toString(): string
     {
@@ -67,8 +58,6 @@ final class BaseURL
      *
      * This is the URL where OAI-PMH requests should be submitted to access
      * this repository's protocol endpoint.
-     *
-     * @return string The base URL of the repository.
      */
     public function getBaseUrl(): string
     {
@@ -78,11 +67,7 @@ final class BaseURL
     /**
      * Checks if this BaseURL is equal to another.
      *
-     * Two BaseURL instances are considered equal if they have the same URL value.
      * Comparison is case-sensitive and does not perform URL normalization.
-     *
-     * @param BaseURL $otherBaseUrl The other BaseURL to compare against.
-     * @return bool True if both BaseURLs are equal, false otherwise.
      */
     public function equals(BaseURL $otherBaseUrl): bool
     {
@@ -97,7 +82,6 @@ final class BaseURL
      * - Valid URL format
      * - HTTP or HTTPS protocol only
      *
-     * @param string $baseUrl The URL to validate.
      * @throws InvalidArgumentException If the URL is invalid or not HTTP/HTTPS.
      */
     private function validateUrl(string $baseUrl): void
@@ -110,7 +94,6 @@ final class BaseURL
     /**
      * Validates that the URL is not empty.
      *
-     * @param string $baseUrl The URL to validate.
      * @throws InvalidArgumentException If the URL is empty.
      */
     private function validateNotEmpty(string $baseUrl): void
@@ -123,7 +106,6 @@ final class BaseURL
     /**
      * Validates that the URL has a valid format.
      *
-     * @param string $baseUrl The URL to validate.
      * @throws InvalidArgumentException If the URL format is invalid.
      */
     private function validateUrlFormat(string $baseUrl): void
@@ -141,7 +123,6 @@ final class BaseURL
      * Per OAI-PMH specification, only HTTP and HTTPS protocols are allowed
      * for repository base URLs.
      *
-     * @param string $baseUrl The URL to validate.
      * @throws InvalidArgumentException If the URL does not use HTTP or HTTPS.
      */
     private function validateHttpProtocol(string $baseUrl): void

--- a/src/Repository/Contract/RecordInterface.php
+++ b/src/Repository/Contract/RecordInterface.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * Contract for OAI-PMH record data access.
+ *
+ * @author    Paul Slits <paul.slits@gmail.com>
+ * @copyright (c) 2026 Paul Slits
+ * @license   MIT License - https://opensource.org/licenses/MIT
+ * @link      https://github.com/pslits/oai-pmh
+ * @since     0.1.0
+ */
+
+declare(strict_types=1);
+
+namespace OaiPmh\Repository\Contract;
+
+use OaiPmh\Domain\ValueObject\RecordIdentifier;
+use OaiPmh\Domain\ValueObject\SetSpec;
+use OaiPmh\Domain\ValueObject\UTCdatetime;
+
+/**
+ * Defines the contract for accessing metadata record data.
+ *
+ * This interface abstracts record retrieval regardless of storage backend
+ * (MySQL, PostgreSQL, file-based, etc.). Implementations should provide
+ * access to all OAI-PMH record properties as defined in the protocol specification.
+ *
+ * According to OAI-PMH 2.0 specification:
+ * - Each record has a unique identifier (section 2.4)
+ * - Records have datestamps indicating when they were created/modified (section 2.7)
+ * - Records may belong to zero or more sets (section 2.6)
+ * - Records may be marked as deleted (section 2.5)
+ * - Records contain metadata in format-specific XML (section 2.5)
+ *
+ * @see http://www.openarchives.org/OAI/openarchivesprotocol.html
+ */
+interface RecordInterface
+{
+    /**
+     * Returns the unique identifier of this record.
+     *
+     * The identifier uniquely identifies this record within the repository
+     * and is used in OAI-PMH requests (GetRecord, ListRecords).
+     *
+     * @return RecordIdentifier The record's unique identifier.
+     */
+    public function getIdentifier(): RecordIdentifier;
+
+    /**
+     * Returns the datestamp when this record was created or last modified.
+     *
+     * The datestamp is expressed in UTC and follows the repository's
+     * declared granularity (date-only or date-time).
+     *
+     * @return UTCdatetime The record's datestamp.
+     */
+    public function getDatestamp(): UTCdatetime;
+
+    /**
+     * Returns the set memberships of this record.
+     *
+     * A record may belong to zero or more sets. Sets provide a mechanism
+     * for selective harvesting (section 2.6 of OAI-PMH specification).
+     *
+     * @return SetSpec[] Array of set specifications (may be empty).
+     */
+    public function getSets(): array;
+
+    /**
+     * Determines whether this record is marked as deleted.
+     *
+     * When a repository supports deleted records (deletedRecord policy is
+     * "transient" or "persistent"), deleted records are included in responses
+     * but with only header information, no metadata.
+     *
+     * @return bool True if the record is deleted, false otherwise.
+     */
+    public function isDeleted(): bool;
+
+    /**
+     * Returns the metadata of this record.
+     *
+     * The metadata is returned as an XML string in the format specific to
+     * the requested metadataPrefix. Returns null for deleted records or
+     * when metadata is not available.
+     *
+     * @return string|null The metadata XML, or null if not available.
+     */
+    public function getMetadata(): ?string;
+}

--- a/src/Repository/Contract/StorageAdapterInterface.php
+++ b/src/Repository/Contract/StorageAdapterInterface.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Contract for storage adapter implementations.
+ *
+ * @author    Paul Slits <paul.slits@gmail.com>
+ * @copyright (c) 2026 Paul Slits
+ * @license   MIT License - https://opensource.org/licenses/MIT
+ * @link      https://github.com/pslits/oai-pmh
+ * @since     0.1.0
+ */
+
+declare(strict_types=1);
+
+namespace OaiPmh\Repository\Contract;
+
+use InvalidArgumentException;
+use OaiPmh\Domain\ValueObject\MetadataPrefix;
+use OaiPmh\Domain\ValueObject\RecordIdentifier;
+use OaiPmh\Domain\ValueObject\SetSpec;
+use OaiPmh\Domain\ValueObject\UTCdatetime;
+
+/**
+ * Defines the contract for storage backend implementations.
+ *
+ * This interface abstracts the storage layer, allowing repositories to implement
+ * various backends (MySQL, PostgreSQL, MongoDB, file-based, etc.) without
+ * coupling the domain layer to a specific storage technology.
+ *
+ * Implementations must provide:
+ * - Record retrieval by identifier
+ * - Record listing with optional filters (metadata format, date range, set)
+ * - Record counting with the same filters
+ * - Earliest datestamp determination for repository identification
+ *
+ * All date filtering follows OAI-PMH selective harvesting rules (section 3.4):
+ * - from: records with datestamp >= from
+ * - until: records with datestamp <= until
+ * - set: records belonging to the specified set
+ *
+ * PAGINATION:
+ * Pagination support will be added when implementing resumption tokens.
+ * The specific approach (offset-based, cursor-based, or stateful) will be
+ * determined based on the chosen resumption token strategy. For now, this
+ * interface remains simple and will be extended as needed.
+ *
+ * @see http://www.openarchives.org/OAI/openarchivesprotocol.html
+ */
+interface StorageAdapterInterface
+{
+    /**
+     * Gets a single record by its identifier.
+     *
+     * This method is used to implement the GetRecord verb, which retrieves
+     * an individual metadata record from a repository.
+     *
+     * @throws InvalidArgumentException If the record does not exist in the repository.
+     */
+    public function getRecord(RecordIdentifier $identifier): RecordInterface;
+
+    /**
+     * Lists records with optional selective harvesting filters.
+     *
+     * This method is used to implement the ListRecords and ListIdentifiers verbs.
+     * All filter parameters are optional; when null, they are not applied.
+     *
+     * Filtering rules:
+     * - metadataPrefix: only records available in this metadata format (optional in storage layer)
+     * - from: only records with datestamp >= from (inclusive)
+     * - until: only records with datestamp <= until (inclusive)
+     * - set: only records that are members of the specified set
+     *
+     * Note: Pagination parameters will be added when implementing resumption tokens.
+     *
+     * @param MetadataPrefix|null $metadataPrefix Optional metadata format filter.
+     * @param UTCdatetime|null $from Optional lower bound for datestamp (inclusive).
+     * @param UTCdatetime|null $until Optional upper bound for datestamp (inclusive).
+     * @param SetSpec|null $set Optional set membership filter.
+     * @return RecordInterface[] Array of records matching the filters (may be empty).
+     */
+    public function listRecords(
+        ?MetadataPrefix $metadataPrefix = null,
+        ?UTCdatetime $from = null,
+        ?UTCdatetime $until = null,
+        ?SetSpec $set = null
+    ): array;
+
+    /**
+     * Counts records matching the specified filters.
+     *
+     * This method supports pagination and flow control by determining the
+     * total number of records that match the filter criteria before fetching them.
+     *
+     * Filter parameters follow the same semantics as listRecords().
+     *
+     * @param MetadataPrefix|null $metadataPrefix Optional metadata format filter.
+     * @param UTCdatetime|null $from Optional lower bound for datestamp (inclusive).
+     * @param UTCdatetime|null $until Optional upper bound for datestamp (inclusive).
+     * @param SetSpec|null $set Optional set membership filter.
+     * @return int The number of records matching the filters (0 if none match).
+     */
+    public function countRecords(
+        ?MetadataPrefix $metadataPrefix = null,
+        ?UTCdatetime $from = null,
+        ?UTCdatetime $until = null,
+        ?SetSpec $set = null
+    ): int;
+
+    /**
+     * Determines the earliest datestamp in the repository.
+     *
+     * This is used in the Identify verb response to indicate the guaranteed
+     * lower limit of all datestamps in the repository (section 3.1.2.6).
+     *
+     * @return UTCdatetime|null The earliest datestamp, or null if the repository is empty.
+     */
+    public function getEarliestDatestamp(): ?UTCdatetime;
+}

--- a/tests/Repository/Contract/FakeRecord.php
+++ b/tests/Repository/Contract/FakeRecord.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * Fake implementation of RecordInterface for testing purposes.
+ *
+ * @author    Paul Slits <paul.slits@gmail.com>
+ * @copyright (c) 2026 Paul Slits
+ * @license   MIT License - https://opensource.org/licenses/MIT
+ * @link      https://github.com/pslits/oai-pmh
+ * @since     0.1.0
+ */
+
+declare(strict_types=1);
+
+namespace OaiPmh\Tests\Repository\Contract;
+
+use OaiPmh\Domain\ValueObject\Granularity;
+use OaiPmh\Domain\ValueObject\RecordIdentifier;
+use OaiPmh\Domain\ValueObject\SetSpec;
+use OaiPmh\Domain\ValueObject\UTCdatetime;
+use OaiPmh\Repository\Contract\RecordInterface;
+
+/**
+ * Fake implementation of RecordInterface for testing purposes.
+ *
+ * This demonstrates that the interface contract is sufficient to represent
+ * any metadata record regardless of storage backend (MySQL, PostgreSQL,
+ * file-based, etc.).
+ *
+ * This fake can be used in any test that needs a RecordInterface implementation
+ * without requiring a real database or storage backend.
+ */
+final class FakeRecord implements RecordInterface
+{
+    private RecordIdentifier $identifier;
+    private UTCdatetime $datestamp;
+    /** @var SetSpec[] */
+    private array $sets;
+    private bool $deleted;
+    private ?string $metadataContent;
+
+    /**
+     * Constructs a fake record.
+     *
+     * @param RecordIdentifier $identifier The record identifier.
+     * @param UTCdatetime|null $datestamp The record datestamp (defaults to 2026-01-01 if null).
+     * @param SetSpec[] $sets The set memberships (defaults to empty array).
+     * @param bool $deleted Whether the record is deleted (defaults to false).
+     * @param string|null $metadataContent The metadata XML content (defaults to null).
+     */
+    public function __construct(
+        RecordIdentifier $identifier,
+        ?UTCdatetime $datestamp = null,
+        array $sets = [],
+        bool $deleted = false,
+        ?string $metadataContent = null
+    ) {
+        $this->identifier = $identifier;
+        $this->datestamp = $datestamp ?? new UTCdatetime(
+            '2026-01-01T00:00:00Z',
+            new Granularity(Granularity::DATE_TIME_SECOND)
+        );
+        $this->sets = $sets;
+        $this->deleted = $deleted;
+        $this->metadataContent = $metadataContent;
+    }
+
+    public function getIdentifier(): RecordIdentifier
+    {
+        return $this->identifier;
+    }
+
+    public function getDatestamp(): UTCdatetime
+    {
+        return $this->datestamp;
+    }
+
+    /**
+     * @return SetSpec[]
+     */
+    public function getSets(): array
+    {
+        return $this->sets;
+    }
+
+    public function isDeleted(): bool
+    {
+        return $this->deleted;
+    }
+
+    public function getMetadata(): ?string
+    {
+        return $this->metadataContent;
+    }
+}

--- a/tests/Repository/Contract/FakeStorageAdapter.php
+++ b/tests/Repository/Contract/FakeStorageAdapter.php
@@ -1,0 +1,159 @@
+<?php
+
+/**
+ * Fake implementation of StorageAdapterInterface for testing purposes.
+ *
+ * @author    Paul Slits <paul.slits@gmail.com>
+ * @copyright (c) 2026 Paul Slits
+ * @license   MIT License - https://opensource.org/licenses/MIT
+ * @link      https://github.com/pslits/oai-pmh
+ * @since     0.1.0
+ */
+
+declare(strict_types=1);
+
+namespace OaiPmh\Tests\Repository\Contract;
+
+use InvalidArgumentException;
+use OaiPmh\Domain\ValueObject\Granularity;
+use OaiPmh\Domain\ValueObject\MetadataPrefix;
+use OaiPmh\Domain\ValueObject\RecordIdentifier;
+use OaiPmh\Domain\ValueObject\SetSpec;
+use OaiPmh\Domain\ValueObject\UTCdatetime;
+use OaiPmh\Repository\Contract\RecordInterface;
+use OaiPmh\Repository\Contract\StorageAdapterInterface;
+
+/**
+ * Fake implementation of StorageAdapterInterface for testing purposes.
+ *
+ * This demonstrates that the interface contract is sufficient for implementing
+ * various storage backends (MySQL, PostgreSQL, MongoDB, file-based, etc.)
+ * without coupling to a specific database implementation.
+ *
+ * This fake can be used in any test that needs a StorageAdapterInterface
+ * implementation without requiring a real database connection.
+ */
+final class FakeStorageAdapter implements StorageAdapterInterface
+{
+    /** @var RecordInterface[] */
+    private array $records;
+
+    /**
+     * Constructs a fake storage adapter.
+     *
+     * @param RecordInterface[]|null $records Initial records to store (creates default test records if null).
+     */
+    public function __construct(?array $records = null)
+    {
+        if ($records === null) {
+            // Create some default test records
+            $granularity = new Granularity(Granularity::DATE_TIME_SECOND);
+            $this->records = [
+                new FakeRecord(
+                    new RecordIdentifier('oai:example.org:item-1'),
+                    new UTCdatetime('2026-01-15T10:00:00Z', $granularity),
+                    [new SetSpec('collection:articles')],
+                    false,
+                    '<dc:title>Article 1</dc:title>'
+                ),
+                new FakeRecord(
+                    new RecordIdentifier('oai:example.org:item-2'),
+                    new UTCdatetime('2026-02-20T14:30:00Z', $granularity),
+                    [new SetSpec('collection:articles'), new SetSpec('collection:open-access')],
+                    false,
+                    '<dc:title>Article 2</dc:title>'
+                ),
+                new FakeRecord(
+                    new RecordIdentifier('oai:example.org:item-3'),
+                    new UTCdatetime('2025-12-10T08:00:00Z', $granularity),
+                    [new SetSpec('collection:books')],
+                    true,
+                    null
+                ),
+            ];
+        } else {
+            $this->records = $records;
+        }
+    }
+
+    public function getRecord(RecordIdentifier $identifier): RecordInterface
+    {
+        foreach ($this->records as $record) {
+            if ($record->getIdentifier()->equals($identifier)) {
+                return $record;
+            }
+        }
+
+        throw new InvalidArgumentException(
+            sprintf('Record not found: %s', $identifier->getRecordIdentifier())
+        );
+    }
+
+    /**
+     * @return RecordInterface[]
+     */
+    public function listRecords(
+        ?MetadataPrefix $metadataPrefix = null,
+        ?UTCdatetime $from = null,
+        ?UTCdatetime $until = null,
+        ?SetSpec $set = null
+    ): array {
+        $filtered = $this->records;
+
+        // Apply from filter
+        if ($from !== null) {
+            $filtered = array_filter($filtered, function (RecordInterface $record) use ($from) {
+                return strcmp($record->getDatestamp()->getDateTime(), $from->getDateTime()) >= 0;
+            });
+        }
+
+        // Apply until filter
+        if ($until !== null) {
+            $filtered = array_filter($filtered, function (RecordInterface $record) use ($until) {
+                return strcmp($record->getDatestamp()->getDateTime(), $until->getDateTime()) <= 0;
+            });
+        }
+
+        // Apply set filter
+        if ($set !== null) {
+            $filtered = array_filter($filtered, function (RecordInterface $record) use ($set) {
+                foreach ($record->getSets() as $recordSet) {
+                    if ($recordSet->equals($set)) {
+                        return true;
+                    }
+                }
+                return false;
+            });
+        }
+
+        // Note: metadataPrefix filtering would depend on additional record metadata
+        // For this fake implementation, we ignore it
+
+        return array_values($filtered);
+    }
+
+    public function countRecords(
+        ?MetadataPrefix $metadataPrefix = null,
+        ?UTCdatetime $from = null,
+        ?UTCdatetime $until = null,
+        ?SetSpec $set = null
+    ): int {
+        return count($this->listRecords($metadataPrefix, $from, $until, $set));
+    }
+
+    public function getEarliestDatestamp(): ?UTCdatetime
+    {
+        if (empty($this->records)) {
+            return null;
+        }
+
+        $earliest = $this->records[0]->getDatestamp();
+        foreach ($this->records as $record) {
+            if (strcmp($record->getDatestamp()->getDateTime(), $earliest->getDateTime()) < 0) {
+                $earliest = $record->getDatestamp();
+            }
+        }
+
+        return $earliest;
+    }
+}

--- a/tests/Repository/Contract/RecordInterfaceTest.php
+++ b/tests/Repository/Contract/RecordInterfaceTest.php
@@ -1,0 +1,183 @@
+<?php
+
+/**
+ * Tests for RecordInterface contract.
+ *
+ * @author    Paul Slits <paul.slits@gmail.com>
+ * @copyright (c) 2026 Paul Slits
+ * @license   MIT License - https://opensource.org/licenses/MIT
+ * @link      https://github.com/pslits/oai-pmh
+ * @since     0.1.0
+ */
+
+declare(strict_types=1);
+
+namespace OaiPmh\Tests\Repository\Contract;
+
+use OaiPmh\Domain\ValueObject\Granularity;
+use OaiPmh\Domain\ValueObject\RecordIdentifier;
+use OaiPmh\Domain\ValueObject\SetSpec;
+use OaiPmh\Domain\ValueObject\UTCdatetime;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that RecordInterface can be implemented and used correctly.
+ *
+ * Uses a fake implementation to verify the contract is sufficient for
+ * representing metadata records regardless of storage backend.
+ */
+final class RecordInterfaceTest extends TestCase
+{
+    /**
+     * User Story:
+     * As a storage adapter developer,
+     * I want to implement RecordInterface with a method to retrieve the record identifier
+     * So that I can uniquely identify records in OAI-PMH responses.
+     */
+    public function testGetIdentifierReturnsRecordIdentifier(): void
+    {
+        // Given: A record with a specific identifier
+        $identifier = new RecordIdentifier('oai:example.org:item-123');
+
+        // When: I create a record with that identifier
+        $record = new FakeRecord($identifier);
+
+        // Then: The record should return the same identifier
+        $this->assertTrue($record->getIdentifier()->equals($identifier));
+    }
+
+    /**
+     * User Story:
+     * As a storage adapter developer,
+     * I want to implement RecordInterface with a method to retrieve the record datestamp
+     * So that I can include creation/modification dates in OAI-PMH responses.
+     */
+    public function testGetDatestampReturnsUTCdatetime(): void
+    {
+        // Given: A specific UTC datestamp
+        $identifier = new RecordIdentifier('oai:example.org:item-123');
+        $granularity = new Granularity(Granularity::DATE_TIME_SECOND);
+        $datestamp = new UTCdatetime('2026-02-21T10:30:00Z', $granularity);
+
+        // When: I create a record with that datestamp
+        $record = new FakeRecord($identifier, $datestamp);
+
+        // Then: The record should return the same datestamp
+        $this->assertTrue($record->getDatestamp()->equals($datestamp));
+    }
+
+    /**
+     * User Story:
+     * As a storage adapter developer,
+     * I want to implement RecordInterface with a method to retrieve set memberships
+     * So that I can support selective harvesting by set in OAI-PMH.
+     */
+    public function testGetSetsReturnsArrayOfSetSpecs(): void
+    {
+        // Given: A record belonging to multiple sets
+        $identifier = new RecordIdentifier('oai:example.org:item-123');
+        $sets = [
+            new SetSpec('collection:articles'),
+            new SetSpec('collection:open-access'),
+        ];
+
+        // When: I create a record with those sets
+        $record = new FakeRecord($identifier, null, $sets);
+
+        // Then: The record should return all set memberships
+        $recordSets = $record->getSets();
+        $this->assertCount(2, $recordSets);
+        $this->assertContainsOnlyInstancesOf(SetSpec::class, $recordSets);
+    }
+
+    /**
+     * User Story:
+     * As a storage adapter developer,
+     * I want RecordInterface to handle records with no set memberships
+     * So that I can represent records not belonging to any set.
+     */
+    public function testGetSetsWhenNoSetsReturnsEmptyArray(): void
+    {
+        // Given: A record not belonging to any set
+        $identifier = new RecordIdentifier('oai:example.org:item-123');
+
+        // When: I create a record with no sets
+        $record = new FakeRecord($identifier, null, []);
+
+        // Then: The record should return an empty array
+        $this->assertSame([], $record->getSets());
+    }
+
+    /**
+     * User Story:
+     * As a storage adapter developer,
+     * I want RecordInterface to indicate when a record is not deleted
+     * So that I can distinguish active records from deleted ones.
+     */
+    public function testIsDeletedWhenNotDeletedReturnsFalse(): void
+    {
+        // Given: An active (non-deleted) record
+        $identifier = new RecordIdentifier('oai:example.org:item-123');
+
+        // When: I create a record that is not deleted
+        $record = new FakeRecord($identifier, null, [], false);
+
+        // Then: The record should indicate it is not deleted
+        $this->assertFalse($record->isDeleted());
+    }
+
+    /**
+     * User Story:
+     * As a storage adapter developer,
+     * I want RecordInterface to indicate when a record is deleted
+     * So that I can support OAI-PMH deletedRecord policies.
+     */
+    public function testIsDeletedWhenDeletedReturnsTrue(): void
+    {
+        // Given: A deleted record
+        $identifier = new RecordIdentifier('oai:example.org:item-123');
+
+        // When: I create a record that is marked as deleted
+        $record = new FakeRecord($identifier, null, [], true);
+
+        // Then: The record should indicate it is deleted
+        $this->assertTrue($record->isDeleted());
+    }
+
+    /**
+     * User Story:
+     * As a storage adapter developer,
+     * I want RecordInterface to provide access to metadata
+     * So that I can include metadata in OAI-PMH GetRecord and ListRecords responses.
+     */
+    public function testGetMetadataReturnsString(): void
+    {
+        // Given: Metadata as XML
+        $identifier = new RecordIdentifier('oai:example.org:item-123');
+        $metadata = '<dc:title>Test Article</dc:title>';
+
+        // When: I create a record with that metadata
+        $record = new FakeRecord($identifier, null, [], false, $metadata);
+
+        // Then: The record should return the metadata
+        $this->assertSame($metadata, $record->getMetadata());
+    }
+
+    /**
+     * User Story:
+     * As a storage adapter developer,
+     * I want RecordInterface to handle records without metadata
+     * So that I can represent deleted records or records pending metadata.
+     */
+    public function testGetMetadataWhenNullReturnsNull(): void
+    {
+        // Given: A record with no metadata
+        $identifier = new RecordIdentifier('oai:example.org:item-123');
+
+        // When: I create a record with null metadata
+        $record = new FakeRecord($identifier, null, [], false, null);
+
+        // Then: The record should return null for metadata
+        $this->assertNull($record->getMetadata());
+    }
+}

--- a/tests/Repository/Contract/StorageAdapterInterfaceTest.php
+++ b/tests/Repository/Contract/StorageAdapterInterfaceTest.php
@@ -1,0 +1,288 @@
+<?php
+
+/**
+ * Tests for StorageAdapterInterface contract.
+ *
+ * @author    Paul Slits <paul.slits@gmail.com>
+ * @copyright (c) 2026 Paul Slits
+ * @license   MIT License - https://opensource.org/licenses/MIT
+ * @link      https://github.com/pslits/oai-pmh
+ * @since     0.1.0
+ */
+
+declare(strict_types=1);
+
+namespace OaiPmh\Tests\Repository\Contract;
+
+use InvalidArgumentException;
+use OaiPmh\Domain\ValueObject\Granularity;
+use OaiPmh\Domain\ValueObject\MetadataPrefix;
+use OaiPmh\Domain\ValueObject\RecordIdentifier;
+use OaiPmh\Domain\ValueObject\SetSpec;
+use OaiPmh\Domain\ValueObject\UTCdatetime;
+use OaiPmh\Repository\Contract\RecordInterface;
+use OaiPmh\Repository\Contract\StorageAdapterInterface;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Tests that StorageAdapterInterface can be implemented and used correctly.
+ *
+ * Uses a fake implementation to verify the contract is sufficient for
+ * implementing various storage backends (MySQL, PostgreSQL, file-based).
+ */
+final class StorageAdapterInterfaceTest extends TestCase
+{
+    private StorageAdapterInterface $adapter;
+
+    protected function setUp(): void
+    {
+        $this->adapter = new FakeStorageAdapter();
+    }
+
+    /**
+     * User Story:
+     * As a repository manager,
+     * I want to retrieve a specific record by its identifier
+     * So that I can implement the OAI-PMH GetRecord verb.
+     */
+    public function testGetRecordWhenRecordExistsReturnsRecord(): void
+    {
+        // Given: A known record identifier exists in the repository
+        $identifier = new RecordIdentifier('oai:example.org:item-1');
+
+        // When: I get the record by identifier
+        $record = $this->adapter->getRecord($identifier);
+
+        // Then: The adapter should return that specific record
+        $this->assertInstanceOf(RecordInterface::class, $record);
+        $this->assertTrue($record->getIdentifier()->equals($identifier));
+    }
+
+    /**
+     * User Story:
+     * As a repository manager,
+     * I want the adapter to throw an exception when a record identifier is not found
+     * So that I can respond with appropriate OAI-PMH idDoesNotExist errors.
+     */
+    public function testGetRecordWhenRecordDoesNotExistThrowsException(): void
+    {
+        // Given: A record identifier that does not exist
+        $identifier = new RecordIdentifier('oai:example.org:non-existent');
+
+        // Then: Getting the record should throw an exception
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Record not found');
+
+        // When: I try to get the non-existent record
+        $this->adapter->getRecord($identifier);
+    }
+
+    /**
+     * User Story:
+     * As a repository manager,
+     * I want to list all records without filters
+     * So that I can implement basic OAI-PMH ListRecords functionality.
+     */
+    public function testListRecordsWithoutFiltersReturnsAllRecords(): void
+    {
+        // Given: A repository with multiple records
+        // (provided by setUp())
+
+        // When: I list records without any filters
+        $records = $this->adapter->listRecords();
+
+        // Then: The adapter should return all records
+        $this->assertGreaterThan(0, count($records));
+        $this->assertContainsOnlyInstancesOf(RecordInterface::class, $records);
+    }
+
+    /**
+     * User Story:
+     * As a repository manager,
+     * I want to filter records by metadata prefix
+     * So that harvesters can request specific metadata formats.
+     */
+    public function testListRecordsWithMetadataPrefixReturnsFilteredRecords(): void
+    {
+        // Given: A metadata prefix filter
+        $metadataPrefix = new MetadataPrefix('oai_dc');
+
+        // When: I list records with that metadata prefix
+        $records = $this->adapter->listRecords($metadataPrefix);
+
+        // Then: The adapter should return records in that format
+        $this->assertContainsOnlyInstancesOf(RecordInterface::class, $records);
+    }
+
+    /**
+     * User Story:
+     * As a repository manager,
+     * I want to filter records by a 'from' date
+     * So that harvesters can perform selective harvesting from a specific date.
+     */
+    public function testListRecordsWithFromDateReturnsRecordsAfterDate(): void
+    {
+        // Given: A date to filter from
+        $granularity = new Granularity(Granularity::DATE_TIME_SECOND);
+        $from = new UTCdatetime('2026-01-01T00:00:00Z', $granularity);
+
+        // When: I list records from that date onwards
+        $records = $this->adapter->listRecords(null, $from);
+
+        // Then: All returned records should have datestamps >= from date
+        foreach ($records as $record) {
+            $this->assertGreaterThanOrEqual(
+                0,
+                strcmp($record->getDatestamp()->getDateTime(), $from->getDateTime())
+            );
+        }
+    }
+
+    /**
+     * User Story:
+     * As a repository manager,
+     * I want to filter records by an 'until' date
+     * So that harvesters can perform selective harvesting up to a specific date.
+     */
+    public function testListRecordsWithUntilDateReturnsRecordsBeforeDate(): void
+    {
+        // Given: A date to filter until
+        $granularity = new Granularity(Granularity::DATE_TIME_SECOND);
+        $until = new UTCdatetime('2026-12-31T23:59:59Z', $granularity);
+
+        // When: I list records up to that date
+        $records = $this->adapter->listRecords(null, null, $until);
+
+        // Then: All returned records should have datestamps <= until date
+        foreach ($records as $record) {
+            $this->assertLessThanOrEqual(
+                0,
+                strcmp($record->getDatestamp()->getDateTime(), $until->getDateTime())
+            );
+        }
+    }
+
+    /**
+     * User Story:
+     * As a repository manager,
+     * I want to filter records by set membership
+     * So that harvesters can perform selective harvesting by collection or category.
+     */
+    public function testListRecordsWithSetReturnsRecordsInSet(): void
+    {
+        // Given: A set specification to filter by
+        $set = new SetSpec('collection:articles');
+
+        // When: I list records in that set
+        $records = $this->adapter->listRecords(null, null, null, $set);
+
+        // Then: All returned records should belong to that set
+        foreach ($records as $record) {
+            $recordSets = $record->getSets();
+            $foundInSet = false;
+            foreach ($recordSets as $recordSet) {
+                if ($recordSet->equals($set)) {
+                    $foundInSet = true;
+                    break;
+                }
+            }
+            $this->assertTrue($foundInSet, 'Record should be in the specified set');
+        }
+    }
+
+    /**
+     * User Story:
+     * As a repository manager,
+     * I want to apply multiple filters simultaneously
+     * So that harvesters can perform complex selective harvesting queries.
+     */
+    public function testListRecordsWithMultipleFiltersReturnsFilteredRecords(): void
+    {
+        // Given: Multiple filter criteria
+        $granularity = new Granularity(Granularity::DATE_TIME_SECOND);
+        $metadataPrefix = new MetadataPrefix('oai_dc');
+        $from = new UTCdatetime('2026-01-01T00:00:00Z', $granularity);
+        $until = new UTCdatetime('2026-12-31T23:59:59Z', $granularity);
+        $set = new SetSpec('collection:articles');
+
+        // When: I list records with all filters applied
+        $records = $this->adapter->listRecords($metadataPrefix, $from, $until, $set);
+
+        // Then: The adapter should return only records matching all criteria
+        $this->assertContainsOnlyInstancesOf(RecordInterface::class, $records);
+    }
+
+    /**
+     * User Story:
+     * As a repository manager,
+     * I want to count the total number of records
+     * So that I can implement pagination and flow control.
+     */
+    public function testCountRecordsWithoutFiltersReturnsTotal(): void
+    {
+        // Given: A repository with multiple records
+        // (provided by setUp())
+
+        // When: I count all records without filters
+        $count = $this->adapter->countRecords();
+
+        // Then: The adapter should return the total record count
+        $this->assertGreaterThanOrEqual(0, $count);
+    }
+
+    /**
+     * User Story:
+     * As a repository manager,
+     * I want to count records matching specific criteria
+     * So that I can determine result set sizes before fetching records.
+     */
+    public function testCountRecordsWithFiltersReturnsFilteredCount(): void
+    {
+        // Given: Filter criteria for selective counting
+        $granularity = new Granularity(Granularity::DATE_TIME_SECOND);
+        $metadataPrefix = new MetadataPrefix('oai_dc');
+        $from = new UTCdatetime('2026-01-01T00:00:00Z', $granularity);
+
+        // When: I count records with those filters
+        $count = $this->adapter->countRecords($metadataPrefix, $from);
+
+        // Then: The adapter should return the filtered count
+        $this->assertGreaterThanOrEqual(0, $count);
+    }
+
+    /**
+     * User Story:
+     * As a repository manager,
+     * I want to determine the earliest datestamp in the repository
+     * So that I can include it in OAI-PMH Identify responses.
+     */
+    public function testGetEarliestDatestampReturnsUTCdatetime(): void
+    {
+        // Given: A repository with multiple records
+        // (provided by setUp())
+
+        // When: I request the earliest datestamp
+        $earliest = $this->adapter->getEarliestDatestamp();
+
+        // Then: The adapter should return a valid UTC datetime
+        $this->assertInstanceOf(UTCdatetime::class, $earliest);
+    }
+
+    /**
+     * User Story:
+     * As a repository manager,
+     * I want the adapter to return null for earliest datestamp when the repository is empty
+     * So that I can handle empty repositories appropriately.
+     */
+    public function testGetEarliestDatestampWhenNoRecordsReturnsNull(): void
+    {
+        // Given: An empty repository
+        $emptyAdapter = new FakeStorageAdapter([]);
+
+        // When: I request the earliest datestamp
+        $earliest = $emptyAdapter->getEarliestDatestamp();
+
+        // Then: The adapter should return null
+        $this->assertNull($earliest);
+    }
+}


### PR DESCRIPTION
## Summary
Implements repository data access layer contracts for OAI-PMH protocol handling.

## Changes
### Core Functionality (US-00102)
-  **RecordInterface**: Contract for OAI-PMH record entities with identifier, datestamp, deleted status, and metadata retrieval
-  **StorageAdapterInterface**: Contract for storage backend adapters supporting record fetching and selective harvesting
-  Comprehensive test coverage with interface contracts and fake implementations

### Documentation & Standards
-  Modernized PHP 8.0 documentation standards (leverage type hints, reduce verbosity)
-  Updated Copilot instructions and Senior Engineer agent guidelines
-  Added php-docblock skill for consistent documentation standards
-  Applied modern docblock style to AnyUri and BaseURL value objects

### Maintenance
-  Fixed composer.json version key typo
-  Added explicit PHP >=8.0 requirement

## Testing
- All interfaces include comprehensive PHPDoc and type hints
- Test coverage includes fake implementations for testing purposes
- Follows project DDD patterns and PSR-12 standards

## Related Issues
Closes #60